### PR TITLE
Support to calculate 100vh for mobile browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=14.16"
   },
   "scripts": {
-    "start": "npm run dev",
+    "start": "yarn run dev",
     "dev": "NODE_ENV=development webpack serve --mode development",
     "build": "NODE_ENV=production webpack --mode production",
     "test": "jest --watch",
@@ -40,7 +40,6 @@
     "i18next": "^21.5.6",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "^1.3.1",
-    "postcss-import": "^14.0.2",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -81,6 +80,7 @@
     "lint-staged": "^12.1.2",
     "mini-css-extract-plugin": "^2.4.5",
     "postcss": "^8.4.5",
+    "postcss-import": "^14.0.2",
     "postcss-loader": "^6.2.1",
     "postcss-nested": "^5.0.6",
     "prettier": "^2.4.1",

--- a/public/index.html
+++ b/public/index.html
@@ -8,5 +8,16 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      const windowResize = () => {
+        const root = document.documentElement
+        const height = window.outerHeight
+
+        root.style.setProperty('--full-height', `${height}px`)
+      }
+
+      windowResize()
+      window.addEventListener('resize', windowResize)
+    </script>
   </body>
 </html>

--- a/src/components/Navbar/index.pcss
+++ b/src/components/Navbar/index.pcss
@@ -18,7 +18,7 @@
   }
 
   &__Nav {
-    @apply w-screen h-[calc(100vh-84px)] max-h-0 overflow-y-hidden absolute top-full left-0 grid grid-rows-[1fr_auto] gap-x-8 bg-neutral-50 px-8;
+    @apply w-screen h-[calc(var(--full-height)-84px)] max-h-0 overflow-y-hidden absolute top-full left-0 grid grid-rows-[1fr_auto] gap-x-8 bg-neutral-50 px-8;
     @apply lg:w-fit lg:h-fit lg:max-h-fit lg:overflow-visible lg:static lg:grid-cols-[repeat(3,_auto)] lg:items-center lg:p-0;
     @apply dark:bg-night-50;
 

--- a/src/styles/global.pcss
+++ b/src/styles/global.pcss
@@ -1,4 +1,8 @@
+:root {
+  --full-height: 100vh;
+}
+
 body {
-  @apply font-sans bg-white text-neutral-900 transform filter;
+  @apply font-sans bg-white text-neutral-900;
   @apply dark:bg-night-100 dark:text-neutral-50;
 }


### PR DESCRIPTION
## 🎯 The problem
A common problem was found in the offcanvas menu when using a high of 100vh which in some mobile browsers adding the interface caused it to scroll more than normal.


The following image visually represents the problem.

![image](https://user-images.githubusercontent.com/57654255/147891304-61f17eb8-0c92-4360-a70a-727fb0f0e8d3.png)



## 🙌 Solution
What the following code does is detect the available height of the browser each time the screen is resized and sets the value within a css variable to be used later in the application styles.

``` javascript
const windowResize = () => {
  const root = document.documentElement
  const height = window.outerHeight

  root.style.setProperty('--full-height', `${height}px`)
}

windowResize()
window.addEventListener('resize', windowResize)
```

To use the css variable it must first be defined in `:root`
``` css
:root {
  --full-height: 100vh;
}

.my-class {
  height: var(--full-height);
}
```
